### PR TITLE
Cleaned up karma responses

### DIFF
--- a/Sources/App/Controllers/Karma/KarmaController+Slack.swift
+++ b/Sources/App/Controllers/Karma/KarmaController+Slack.swift
@@ -21,13 +21,13 @@ extension KarmaController {
         }
 
         // Do this in the background
-        send(karmaStatuses: process(karmaCommand: content), to: responseUrl, with: req, command: content)
+        send(karmaStatuses: process(karmaCommand: content, on: req), to: responseUrl, with: req, command: content)
 
         // Respond immediately
         return .ok
     }
 
-    private func process(karmaCommand command: Command) -> Future<[KarmaStatus]> {
+    private func process(karmaCommand command: Command, on req: Request) -> Future<[KarmaStatus]> {
         let repository = karmaStatusRepository
 
         switch command.command {
@@ -37,7 +37,7 @@ extension KarmaController {
             let userIds = karmaParser.userIds(from: command.text ?? "")
             return repository.find(ids: userIds)
         default:
-            return repository.find(ids: [])
+            return req.future(error: Abort(.badRequest))
         }
     }
 

--- a/Sources/App/Controllers/Karma/KarmaController.swift
+++ b/Sources/App/Controllers/Karma/KarmaController.swift
@@ -27,9 +27,12 @@ final class KarmaController {
 
 extension KarmaController: RouteCollection {
     func boot(router: Router) throws {
-        registerStatusRoutes(on: router)
-        registerHistoryRoutes(on: router)
         registerSlackRoutes(on: router)
+
+//        Don't need to enable these right now
+//
+//        registerStatusRoutes(on: router)
+//        registerHistoryRoutes(on: router)
     }
 }
 

--- a/Sources/App/Models/Karma/KarmaStatusResponse.swift
+++ b/Sources/App/Models/Karma/KarmaStatusResponse.swift
@@ -71,7 +71,7 @@ extension KarmaStatusResponse {
         var fields: [[String:Any]] = [["title": "User", "short": true], ["title": "Karma", "short": true]]
 
         statuses.forEach { status in
-            fields.append(["value": status.id?.asSlackUserMention() as Any, "short": true])
+            fields.append(["value": "\(status.id?.asSlackUserMention() ?? "") (\(emojiRelation(total: status.count)))", "short": true])
             fields.append(["value": status.count.description, "short": true])
         }
 

--- a/Sources/App/Models/Karma/KarmaStatusResponse.swift
+++ b/Sources/App/Models/Karma/KarmaStatusResponse.swift
@@ -26,8 +26,8 @@ class KarmaStatusResponse: SlackKitResponse {
 
     init(forKarmaAdjustingMessage incomingMessage: SlackKitIncomingMessage, receivedKarma: KarmaAdjustment, statusAfterChange karmaStatus: KarmaStatus) {
         super.init(to: incomingMessage,
-                   text: receivedKarma.user.asSlackUserMention(),
-                   attachments: [KarmaStatusResponse.slackAttachment(with: receivedKarma, totalKarma: karmaStatus.count)])
+                   text: "",
+                   attachments: [KarmaStatusResponse.slackAttachment(with: receivedKarma, totalKarma: karmaStatus.count, userId: receivedKarma.user.asSlackUserMention())])
     }
 }
 
@@ -50,10 +50,10 @@ extension KarmaStatusResponse {
         return karma.count >= 0 ? "increased" : "decreased"
     }
 
-    static func slackAttachment(with receivedKarma: KarmaAdjustment, totalKarma: Int) -> Attachment {
+    static func slackAttachment(with receivedKarma: KarmaAdjustment, totalKarma: Int, userId: String) -> Attachment {
         return Attachment(attachment: ["fallback": defaultMessage(karma: receivedKarma),
                                        "color": messageColor(karmaCount: receivedKarma.count),
-            "text": "Karma \(changed(karma: receivedKarma)) to \(totalKarma) \(emojiRelation(total: totalKarma))"])
+                                       "text": "\(userId) (\(emojiRelation(total: totalKarma))): Karma \(changed(karma: receivedKarma)) to \(totalKarma)"])
     }
 
     static func slashCommandSlackAttachment(karmaStatus: KarmaStatus) -> Attachment {
@@ -63,7 +63,7 @@ extension KarmaStatusResponse {
     }
 
     private static func currentCountText(karmaStatus: KarmaStatus, fallback: Bool) -> String {
-        return "\((fallback ? karmaStatus.id : karmaStatus.id?.asSlackUserMention()) ?? "Something") has \(karmaStatus.count) karma \(emojiRelation(total: karmaStatus.count))"
+        return "\((fallback ? karmaStatus.id : karmaStatus.id?.asSlackUserMention()) ?? "Something") (\(emojiRelation(total: karmaStatus.count))): \(karmaStatus.count) karma "
     }
 
     private static func emojiRelation(total: Int) -> String {


### PR DESCRIPTION
Resolves #45 

Thought this was a simple fix that also visually looks better 

Karma adjustment response
<img width="327" alt="Screen Shot 2019-03-11 at 4 03 00 PM" src="https://user-images.githubusercontent.com/29609538/54157870-307dd400-4417-11e9-864d-145d245d5fb0.png">

/karma response
<img width="245" alt="Screen Shot 2019-03-11 at 4 03 06 PM" src="https://user-images.githubusercontent.com/29609538/54157869-307dd400-4417-11e9-9014-22766ff7fdfc.png">
