### PR TITLE
Simplify listener and lean into the ways of Vapor

### DIFF
--- a/Sources/App/Controllers/Karma/KarmaController+Slack.swift
+++ b/Sources/App/Controllers/Karma/KarmaController+Slack.swift
@@ -6,6 +6,7 @@
 //
 
 import Vapor
+import struct SlackKit.User
 
 extension KarmaController {
     func registerSlackRoutes(on router: Router) {
@@ -71,7 +72,7 @@ extension KarmaController {
 
 extension KarmaController: SlackResponder {
 
-    func handle(incomingMessage: SlackKitIncomingMessage) throws {
+    func handle(incomingMessage: SlackKitIncomingMessage, forBotUser botUser: User) throws {
 
         let karmaChanges = karmaParser.karmaAdjustments(from: incomingMessage.text)
 

--- a/Sources/App/Controllers/Karma/KarmaController.swift
+++ b/Sources/App/Controllers/Karma/KarmaController.swift
@@ -38,17 +38,10 @@ extension KarmaController: RouteCollection {
 
 extension KarmaController: ServiceType {
     static func makeService(for container: Container) throws -> KarmaController {
-        let slack = try container.make(Slack.self)
-        let karmaController = KarmaController(karmaStatusRepository: try container.make(),
-                                              karmaHistoryRepository: try container.make(),
-                                              slack: slack,
-                                              log: try container.make(),
-                                              secrets: try container.make())
-
-        slack.register(responder: karmaController, on: container)
-
-        return karmaController
+        return KarmaController(karmaStatusRepository: try container.make(),
+                               karmaHistoryRepository: try container.make(),
+                               slack: try container.make(),
+                               log: try container.make(),
+                               secrets: try container.make())
     }
 }
-
-

--- a/Sources/App/Controllers/OnTap/OnTapController+Slack.swift
+++ b/Sources/App/Controllers/OnTap/OnTapController+Slack.swift
@@ -6,11 +6,11 @@
 //
 
 import Foundation
+import struct SlackKit.User
 
 extension OnTapController: SlackResponder {
 
-    func handle(incomingMessage: SlackKitIncomingMessage) throws {
-        guard let botUser = slack.botUser else { return }
+    func handle(incomingMessage: SlackKitIncomingMessage, forBotUser botUser: User) throws {
         guard let directedTo = incomingMessage.text.userIDMentionedBeforeAnyOtherContent() else { return }
         guard botUser.id == directedTo else { return }
 

--- a/Sources/App/Controllers/OnTap/OnTapController.swift
+++ b/Sources/App/Controllers/OnTap/OnTapController.swift
@@ -14,8 +14,8 @@ final class OnTapController {
     let log: Logger
     let secrets: Secrets
 
-    init(slackClient: Slack, logger: Logger, secrets: Secrets) {
-        self.slack = slackClient
+    init(slack: Slack, logger: Logger, secrets: Secrets) {
+        self.slack = slack
         self.log = logger
         self.secrets = secrets
     }
@@ -24,11 +24,7 @@ final class OnTapController {
 extension OnTapController: ServiceType {
 
     static func makeService(for container: Container) throws -> OnTapController {
-        let slack = try container.make(Slack.self)
-        let onTap = OnTapController(slackClient: slack, logger: try container.make(), secrets: try container.make())
-        slack.register(responder: onTap, on: container)
-
-        return onTap
+        return OnTapController(slack: try container.make(), logger: try container.make(), secrets: try container.make())
     }
 }
 

--- a/Sources/App/Slack/Slack.swift
+++ b/Sources/App/Slack/Slack.swift
@@ -10,27 +10,16 @@ import Vapor
 
 struct Slack: ServiceType {
     private let slackKit = SlackKit()
-    private let listener: SlackListener
     private let log: Logger
-
-    public var botUser: User? {
-        return listener.botUser
-    }
 
     static func makeService(for container: Container) throws -> Slack {
         return Slack(secrets: try container.make(),
-                     listener: try container.make(),
                      logger: try container.make())
     }
 
-    init(secrets: Secrets, listener: SlackListener, logger: Logger) {
-        self.listener = listener
+    init(secrets: Secrets, logger: Logger) {
         self.log = logger
         slackKit.addWebAPIAccessWithToken(secrets.slackAppBotUserAPI)
-    }
-
-    func register(responder: SlackResponder, on worker: Worker) {
-        listener.register(responder: responder, on: worker)
     }
 
     func send(message: SlackKitSendable) throws {

--- a/Sources/App/Slack/SlackResponder.swift
+++ b/Sources/App/Slack/SlackResponder.swift
@@ -8,15 +8,11 @@
 import SlackKit
 
 protocol SlackResponder {
-    static var serviceName: String { get }
-    var eventTypes: [EventType] { get }
-    func handle(incomingMessage: SlackKitIncomingMessage) throws
-    func handle(event: Event) throws
+    func handle(incomingMessage: SlackKitIncomingMessage, forBotUser botUser: User) throws
+    func handle(event: Event, ofType type: EventType, forBotUser botUser: User) throws
 }
 
 extension SlackResponder {
-    static var serviceName: String { return String(reflecting: self) }
-    var eventTypes: [EventType] { return [.message] }
-    func handle(incomingMessage: SlackKitIncomingMessage) { }
-    func handle(event: Event) { }
+    func handle(incomingMessage: SlackKitIncomingMessage, forBotUser botUser: User) throws { }
+    func handle(event: Event, ofType type: EventType, forBotUser botUser: User) throws { }
 }

--- a/Sources/App/Slack/SlackRouter.swift
+++ b/Sources/App/Slack/SlackRouter.swift
@@ -1,0 +1,41 @@
+//
+//  SlackRouter.swift
+//  App
+//
+//  Created by Allen Humphreys on 3/13/19.
+//
+
+import SlackKit
+import Vapor
+
+protocol SlackRouter: SlackResponder {
+    func register(responder: SlackResponder, for eventTypes: [EventType])
+}
+
+// Currently we don't support any registration of more specific routes,
+// everyone gets everything. In the future, a proper Route type should be developed
+// to provide the router with enough information to decide who to actually deliver things to
+public final class StandardSlackRouter: Service, SlackRouter {
+    private var responders = [EventType: [SlackResponder]]()
+
+    func register(responder: SlackResponder, for eventTypes: [EventType]) {
+
+        eventTypes.forEach {
+            var respondersForType = responders[$0] ?? []
+            respondersForType.append(responder)
+            responders[$0] = respondersForType
+        }
+    }
+
+    func handle(event: Event, ofType type: EventType, forBotUser botUser: User) throws {
+
+        if type == .message, let message = SlackKitIncomingMessage(event: event) {
+
+            try responders[.message]?.forEach { try $0.handle(incomingMessage: message, forBotUser: botUser) }
+            return
+        }
+
+        // Fallback to the generic event handler
+        try responders[type]?.forEach { try $0.handle(event: event, ofType: type, forBotUser: botUser) }
+    }
+}

--- a/Sources/App/Slack/slackRoutes.swift
+++ b/Sources/App/Slack/slackRoutes.swift
@@ -1,0 +1,15 @@
+//
+//  slackRoutes.swift
+//  App
+//
+//  Created by Allen Humphreys on 3/13/19.
+//
+
+import Vapor
+
+/// Register your application's slack routes here.
+func slackRoutes(_ router: SlackRouter, _ container: Container) throws {
+
+    router.register(responder: try container.make(KarmaController.self), for: [.message])
+    router.register(responder: try container.make(OnTapController.self), for: [.message])
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -40,5 +40,6 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
     services.register(KarmaController.self)
     services.register(try Secrets.detect(), as: Secrets.self)
     services.register(Slack.self)
-    services.register(SlackListener.self)
+
+    try services.register(SlackListenerProvider())
 }


### PR DESCRIPTION
In the future, the router could support various things, such as registering patterns for commands, etc to simplify/centralize code. This follows the same basic delivery patterns already in place, but arranged more elegantly.